### PR TITLE
README.md: Domain should be of type integer

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ pip install py_ecc
 ```python
 from py_ecc import bls
 
-domain = 43
+domain = b'\x43'
 
 private_key = 5566
 public_key = bls.privtopub(private_key)


### PR DESCRIPTION
### What was wrong?

Example in README.md does not work.
Triggers a TypeError on the bls.sign call.

### How was it fixed?

Changed domain from 43 (int) to b'\x43' (bytes).

